### PR TITLE
Fix holes in mesh (boundary edges)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To run geoCruncher need other libraries to be installed. The followings needs to
 
 * Eigen
 * GmLib by brgm (Commit 2c7736a57906c48a8edfbc6348f0477512debbd6 or later)
-* MeshTools by brgm (Commit 20e68f3bcc0581cbc79affb6abc7b470fe0243fb or later)
+* MeshTools by brgm (Commit 5923bad641f5fe82622a0b33e73806177a0f4690 or later)
 * scikit-image >= 0.14.0
 * CGAL >= 4.13
 * numpy

--- a/geocruncher/MeshGeneration.py
+++ b/geocruncher/MeshGeneration.py
@@ -64,6 +64,11 @@ def generate_volumes(model: GeologicalModel, shape: (int,int,int), outDir: str):
 
         verts, faces, normals, values = marching_cubes(indicator, level=0.5, gradient_direction="ascent") # Gradient direction ensures normals point outwards
         tsurf = CGAL.TSurf(rescale_to_grid(verts, box, shape), faces)
+
+        # Repair mesh if there are border edges. Mesh must be closed.
+        if not tsurf.is_closed():
+            CGAL.fix_border_edges(tsurf)
+
         meshes[rank] = tsurf
 
     out_files = defaultdict(list)


### PR DESCRIPTION
Occasionally the generated meshes can have boundary edges, meaning that the mesh isn't "closed". A non-closed mesh makes further processing unreliable.

This PR adds a check and repairs meshes that are not closed.

Relies on my merge request for MeshTools https://gitlab.inria.fr/charms/MeshTools/merge_requests/34