### PR TITLE
Remove pytestrunner as package is deprecated

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = test_*.py

--- a/runner_test.py
+++ b/runner_test.py
@@ -1,0 +1,16 @@
+import sys
+
+from setuptools.command.test import test as TestCommand
+
+class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
+
+    def run_tests(self):
+        #import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [bdist_wheel]
 universal=0
-
-[aliases]
-test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
 from setuptools import setup, find_packages
 
+from runner_test import PyTest
+
 setup(
     name='geocruncher',
     version='0.3.1',
     description='A bridge between Gmlib and VK',
     packages=find_packages(exclude=['doc']),
     python_requires='>=3',
-    setup_requires=['pytest-runner'],
     install_requires=['numpy'],
     tests_require=['pytest'],
+    cmdclass = {'test': PyTest},
 #    scripts=['GeoCruncher/main.py']
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
This may help to fix the build:
Currently, we have the following error while building gmlib:

```
<3>Traceback (most recent call last):
<3>  File "/nix/store/5baqrdgkx4x768q1ypz8pxncr7rsb1ih-python3.7-pluggy-0.8.1/lib/python3.7/site-packages/pluggy/manager.py", line 268, in load_setuptools_entrypoints
<3>    plugin = ep.load()
<3>  File "/nix/store/s78zn07rr066nbkm9wnn42nn3g8k929s-python3.7-bootstrapped-pip-19.0.3/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2410, in load
<3>    self.require(*args, **kwargs)
<3>  File "/nix/store/s78zn07rr066nbkm9wnn42nn3g8k929s-python3.7-bootstrapped-pip-19.0.3/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2433, in require
<3>    items = working_set.resolve(reqs, env, installer, extras=self.extras)
<3>  File "/nix/store/s78zn07rr066nbkm9wnn42nn3g8k929s-python3.7-bootstrapped-pip-19.0.3/lib/python3.7/site-packages/pkg_resources/__init__.py", line 791, in resolve
<3>    raise VersionConflict(dist, req).with_context(dependent_req)
<3>pkg_resources.VersionConflict: (pytest 4.2.1 (/nix/store/3ymqqzq84hsrr67ah8rq18r40mrb6phg-python3.7-pytest-4.2.1/lib/python3.7/site-packages), Requirement.parse('pytest<4.0.0'))
```
And I suspect that it is caused by the pytestrunner package, as it is deprecated

Will go with: https://github.com/ISSKA/viskar-ops/pull/11