### PR TITLE
Fix orientation of tunnel meshes when in negative y quadrants and add test

### DIFF
--- a/geocruncher/tunnel_shape_generation.py
+++ b/geocruncher/tunnel_shape_generation.py
@@ -64,16 +64,33 @@ def get_rectangle_segment(width, height, nb_vertices):
     """
     length = 2 * width + 2 * height
     points = []
+    current_state = -1
     for i in range(nb_vertices): 
         distance = length * i / nb_vertices
         if distance < height:
-            points.append(np.array([-distance, width / 2, 0]))
+            if current_state == -1:
+                points.append(np.array([0, width/2, 0]))
+                current_state += 1
+            else:
+                points.append(np.array([-distance, width / 2, 0]))
         elif distance < height + width:
-            points.append(np.array([-height, -(distance - height - width / 2), 0]))
+            if current_state == 0:
+                points.append(np.array([-height, width/2, 0]))
+                current_state += 1
+            else:
+                points.append(np.array([-height, -(distance - height - width / 2), 0]))
         elif distance < 2 * height + width:
-            points.append(np.array([-(2 * height + width - distance), -width / 2, 0]))
+            if current_state == 1:
+                points.append(np.array([-height, -width/2, 0]))
+                current_state += 1
+            else:
+                points.append(np.array([-(2 * height + width - distance), -width / 2, 0]))
         else:
-            points.append(np.array([0, -(2 * height + 3 * width / 2 - distance), 0]))
+            if current_state == 2:
+                points.append(np.array([0, -width/2, 0]))
+                current_state += 1
+            else:
+                points.append(np.array([0, -(2 * height + 3 * width / 2 - distance), 0]))
     return points
 
 def get_elliptic_segment(width, height, nb_vertices):

--- a/geocruncher/tunnel_shape_generation.py
+++ b/geocruncher/tunnel_shape_generation.py
@@ -115,8 +115,12 @@ def _project_points(normal, bottom, xy_points):
         diff_axis = to_plane_rotation.dot(z)
         diff_axis[2] = 0
         angle2 = math.acos(np.dot(normalize(diff_axis), x))
+        cond = angle2 > ANGLE_EPSILON
         rotation_matrix = None
-        if angle2 > ANGLE_EPSILON:
+        if normal[1] < 0:
+            angle2 *= -1
+            cond = -angle2 > ANGLE_EPSILON
+        if cond:
             in_plane_rotation = _rotation_matrix(u, angle2)
             rotation_matrix = np.matmul(in_plane_rotation, to_plane_rotation)
         else:

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -22,5 +22,5 @@ def test_bottomPointsShouldHaveSameZ():
         verts = _project_points(normal, bottom, xy_points)
         zc = [v[2] for v in verts]
         d = max(zc) - min(zc)
-        assert np.std(zc) === 0, "Test failed for: the following setup: " + str({"difference": str(d), "length": str(
+        assert d < 0.3, "Test failed for: the following setup: " + str({"difference": str(d), "length": str(
             length), "nb_vertices": str(nb_vertices), "xy_points": str(xy_points), "normal": normal, "bottom": bottom, "verts": str(verts)})

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -1,0 +1,26 @@
+import pytest
+
+import numpy as np
+from geocruncher.tunnel_shape_generation import _project_points
+from random import uniform, randint
+
+def _make_straight_segment(length, nb_vertices):
+    points = []
+    for i in range(nb_vertices):
+        distance = length * i / nb_vertices
+        points.append(np.array([0, distance - length/2, 0]))
+    return points
+
+def test_bottomPointsShouldHaveSameZ():
+    for _ in range(100):
+        length = uniform(1, 200)
+        nb_vertices = randint(5, 35)
+        xy_points = _make_straight_segment(length, nb_vertices)
+        normal = [uniform(-10, 10), uniform(-10, 10), uniform(0, 10)]
+        bottom = [uniform(-10, 10), uniform(-10, 10), uniform(-10, 10)]
+
+        verts = _project_points(normal, bottom, xy_points)
+        zc = [v[2] for v in verts]
+        d = max(zc) - min(zc)
+        assert np.std(zc) === 0, "Test failed for: the following setup: " + str({"difference": str(d), "length": str(
+            length), "nb_vertices": str(nb_vertices), "xy_points": str(xy_points), "normal": normal, "bottom": bottom, "verts": str(verts)})


### PR DESCRIPTION
See: https://trello.com/c/YmLofaFG/1438-improve-galleries-meshes and https://trello.com/c/YYxHZvuP/1349-bug-gallery-meshes-are-not-correctly-oriented

TODO:
- [x] Check for _strange layout in "stairs" instead of "tube"_