### PR TITLE
Fixed OFF rounding bug

### DIFF
--- a/geocruncher/MeshGeneration.py
+++ b/geocruncher/MeshGeneration.py
@@ -151,7 +151,10 @@ def generate_faults_files(model: GeologicalModel, shape: (int, int, int), outDir
     for name, fault in faults.items():
         filename = 'fault_%s.off' % name
         out_file = os.path.join(outDir, filename)
-        fault.to_off(out_file)
+
+        off_mesh = generate_off(*fault.as_arrays())
+        with open(out_file,'w',encoding='utf8') as f:
+            f.write(off_mesh)
         out_files[name].append(out_file)
     return out_files
 

--- a/geocruncher/MeshGeneration.py
+++ b/geocruncher/MeshGeneration.py
@@ -11,6 +11,33 @@ from gmlib.tesselate import Tesselator
 from gmlib.tesselate import TopographyClipper
 from skimage.measure import marching_cubes_lewiner as marching_cubes
 
+def generate_off(verts, faces, precision=3):
+    """Generates a valid OFF string from the given verts and faces.
+
+    Parameters:
+        verts: (V, 3) array
+            Spatial coordinates for V unique mesh vertices. Coordinate order
+            must be (x, y, z).
+        faces: (F, N) array
+            Define F unique faces of N size via referencing vertex indices from ``verts``.
+        precision: int
+            How many decimals to keep when writing vertex position. Defaults to 3.
+
+    Returns:
+        str: A valid OFF string.
+    """
+    # Implementation reference: https://en.wikipedia.org/wiki/OFF_(file_format)#Composition
+    num_verts = len(verts)
+    num_faces = len(faces)
+    v = '\n'.join([' '.join([str(round(float(position), precision)) for position in vertex]) for vertex in verts])
+    f = '\n'.join([' '.join([str(len(face)), *(str(int(index)) for index in face)]) for face in faces])
+
+    return "OFF\n{num_verts} {num_faces} 0\n{vertices}\n{faces}\n".format(
+        num_verts=num_verts,
+        num_faces=num_faces,
+        vertices=v,
+        faces = f)
+
 def generate_volumes(model: GeologicalModel, shape: (int, int, int), outDir: str, optBox: Box = None):
     """Generates topologically valid meshes for each unit in the model. Meshes are output in OFF format.
 
@@ -93,7 +120,10 @@ def generate_volumes(model: GeologicalModel, shape: (int, int, int), outDir: str
     for rank, mesh in meshes.items():
         filename = 'rank_%d.off' % rank
         out_file = os.path.join(outDir, filename)
-        mesh.to_off(out_file)
+
+        off_mesh = generate_off(*mesh.as_arrays())
+        with open(out_file,'w',encoding='utf8') as f:
+            f.write(off_mesh)
         out_files["mesh"][str(rank)].append(out_file)
 
     with open(os.path.join(outDir, 'index.json'), 'w') as f:

--- a/geocruncher/tunnel_shape_generation.py
+++ b/geocruncher/tunnel_shape_generation.py
@@ -3,7 +3,7 @@ import numpy as np
 from sympy.parsing.sympy_parser import parse_expr
 from sympy import diff, symbols
 import scipy.integrate as integrate
-import MeshTools.CGALWrappers as CGAL
+from .MeshGeneration import generate_off
 
 def tunnel_to_meshes(functions, step, xy_points, idxStart, tStart, idxEnd, tEnd, outFile):
     """Generate a mesh for a tunnel
@@ -32,7 +32,9 @@ def tunnel_to_meshes(functions, step, xy_points, idxStart, tStart, idxEnd, tEnd,
                 vertices.append(p)
             nb_series += 1
     triangles = _connect_vertices(len(xy_points), nb_series)
-    CGAL.TSurf(vertices, np.array(triangles)).to_off(outFile)
+    off_mesh = generate_off(vertices, np.array(triangles))
+    with open(outFile,'w',encoding='utf8') as f:
+        f.write(off_mesh)
     return vertices
 
 def get_circle_segment(radius, nb_vertices):


### PR DESCRIPTION
Implemented our own OFF encoder

CGAL's OFF exporter was using exponent notation to write big floats to the disk. That caused values to be rounded at the nearest 10th for most of our projects (because of their location in the world).
By making our own exporter, we can avoid that problem and choose exactly how much precision we want.

I was able to keep everything else intact, and even still use CGAL to close the mesh, or do any other manipulation in the future.

See: https://trello.com/c/x7ZHmgfO/1469-unexpected-shapes-for-meshes-with-resolution-10m