### PR TITLE
Proportional intersection resolution

### DIFF
--- a/geocruncher/ComputeIntersections.py
+++ b/geocruncher/ComputeIntersections.py
@@ -8,11 +8,33 @@ from gmlib.architecture import from_GeoModeller, make_evaluator
 from .profiler.profiler import get_current_profiler
 from .mesh_io.mesh_io import read_mesh_to_polydata
 
+def calculate_resolution(width: float, height: float, res: int) -> tuple[int, int]:
+    """Calculates a proportional resolution where the larger dimension matches `res`.
+    
+    The smaller dimension is scaled to maintain the original aspect ratio, with rounding
+    to the nearest integer.
+
+    Args:
+        width: Original width (float, accepts non-integer ratios).
+        height: Original height (float, accepts non-integer ratios).
+        res: Target resolution (int) for the larger dimension.
+
+    Returns:
+        Tuple[int, int]: New (width, height) where one dimension equals `res`.
+    """
+    if width >= height:
+        new_width = res
+        new_height = int(round(height * (res / width)))
+    else:
+        new_height = res
+        new_width = int(round(width * (res / height)))
+    return (new_width, new_height)
+
 def compute_vertical_slice_points(
     x_coord: tuple[int, int],
     y_coord: tuple[int, int],
     z_coord: tuple[int, int],
-    n_points: int
+    resolution: tuple[int, int]
 ) -> np.ndarray:
     """Calculate 3D points along a vertical slice plane.
 
@@ -24,13 +46,13 @@ def compute_vertical_slice_points(
         Start and end y-coordinates of the slice line.
     z_coord : tuple[int, int]
         Start and end z-coordinates defining the vertical range of the slice.
-    n_points : int
-        Number of points to generate along each dimension.
+    resolution : tuple[int, int]
+        Width resolution and Height resolution.
 
     Returns
     -------
     np.ndarray
-        Array of shape (n_points^2, 3) containing the (x, y, z) coordinates of points
+        Array of shape (resolution[0]*resolution[1], 3) containing the (x, y, z) coordinates of points
         in the slice plane.
 
     Notes
@@ -39,37 +61,36 @@ def compute_vertical_slice_points(
     start and end coordinates. For y-axis-aligned slices, x remains constant
     while y varies linearly.
     """
-
-    z_slice_range = np.linspace(z_coord[0], z_coord[1], n_points)
+    z_slice_range = np.linspace(z_coord[0], z_coord[1], resolution[1])
 
     if not x_coord[0] == x_coord[1]:
-        x_slice_range = np.linspace(x_coord[0], x_coord[1], n_points)
+        x_slice_range = np.linspace(x_coord[0], x_coord[1], resolution[0])
         slope = (y_coord[0] - y_coord[1]) / (x_coord[0] - x_coord[1])
         z, x = np.meshgrid(z_slice_range, x_slice_range)
         y = slope * (x - x_coord[0]) + y_coord[0]
     else:
-        y_slice_range = np.linspace(y_coord[0], y_coord[1], n_points)
+        y_slice_range = np.linspace(y_coord[0], y_coord[1], resolution[0])
         z, y = np.meshgrid(z_slice_range, y_slice_range)
         x = np.full_like(y, x_coord[0])
     xyz = np.stack((x.ravel(), y.ravel(), z.ravel()), axis=-1)
     return xyz
 
-def compute_map_points(box: Box, n_points: int, model: GeologicalModel) -> np.ndarray:
+def compute_map_points(box: Box, resolution: tuple[int, int], model: GeologicalModel) -> np.ndarray:
     """Compute points for a top-down geological cross section.
 
     Parameters
     ----------
     box : Box
         The bounding box of the geological model.
-    n_points : int
-        Number of points in each dimension of the map cross section.
+    resolution : tuple[int, int]
+        Width resolution and Height resolution.
     model : gmlib.GeologicalModel3D.GeologicalModel
         The GeologicalModel from gmlib to use for the topography evaluation.
     
     Returns
     -------
     np.ndarray
-        A numpy array of shape (n_points^2, 3) containing the (x, y, z) coordinates of the points.
+        A numpy array of shape (resolution[0]*resolution[1], 3) containing the (x, y, z) coordinates of the points.
     
     Notes
     -----
@@ -77,8 +98,8 @@ def compute_map_points(box: Box, n_points: int, model: GeologicalModel) -> np.nd
     The returned points are ordered in a grid pattern, sorted by x, then y.
     """
 
-    x_map_range = np.linspace(box.xmin, box.xmax, n_points)
-    y_map_range = np.linspace(box.ymin, box.ymax, n_points)
+    x_map_range = np.linspace(box.xmin, box.xmax, resolution[0])
+    y_map_range = np.linspace(box.ymin, box.ymax, resolution[1])
     y, x = np.meshgrid(y_map_range, x_map_range)
     xy = np.stack([x.ravel(), y.ravel()], axis=1)
     z = model.topography.evaluate_z(xy)
@@ -87,7 +108,7 @@ def compute_map_points(box: Box, n_points: int, model: GeologicalModel) -> np.nd
 
 def compute_cross_section_ranks(
     xyz: np.ndarray,
-    n_points: int,
+    resolution: tuple[int, int],
     model: GeologicalModel,
     topography: bool = False
 ) -> list:
@@ -96,9 +117,9 @@ def compute_cross_section_ranks(
     Parameters
     ----------
     xyz : np.ndarray
-       Array of 3D coordinates where the ranks will be evaluated, shape (n_points^2, 3)
-    n_points : int
-        Number of points in each dimension of the cross section.
+       Array of 3D coordinates where the ranks will be evaluated, shape (resolution[0]*resolution[1], 3)
+    resolution : tuple[int, int]
+        x is the width resolution, y is the height resolution.
     model : gmlib.GeologicalModel3D.GeologicalModel
         The GeologicalModel from gmlib to use for the formation rank evaluation.
     topography : bool, optional
@@ -108,7 +129,7 @@ def compute_cross_section_ranks(
     Returns
     -------
     list
-        A list of ranks after evaluation, reshaped to (n_points, n_points).
+        A list of ranks after evaluation, reshaped to resolution.
 
     Notes
     -----
@@ -126,7 +147,7 @@ def compute_cross_section_ranks(
     rank_offset = -1 if is_base else 0
 
     ranks = evaluator(xyz) + rank_offset
-    ranks.shape = (n_points, n_points)
+    ranks.shape = resolution
     ranks = ranks.tolist()
     get_current_profiler().profile('cross_section_ranks')
     return ranks

--- a/geocruncher/computations.py
+++ b/geocruncher/computations.py
@@ -4,12 +4,13 @@
 """
 
 import numpy as np
+import math
 from typing import TypedDict
 from enum import Enum
 from gmlib.GeologicalModel3D import GeologicalModel
 from gmlib.GeologicalModel3D import Box
 
-from .ComputeIntersections import compute_vertical_slice_points, project_hydro_features_on_slice, compute_map_points, compute_cross_section_ranks
+from .ComputeIntersections import compute_vertical_slice_points, project_hydro_features_on_slice, compute_map_points, compute_cross_section_ranks, calculate_resolution
 from .fault_intersections import compute_fault_intersections
 from .MeshGeneration import generate_volumes, generate_faults_files
 from .geomodeller_import import extract_project_data
@@ -256,8 +257,6 @@ def compute_intersections(data: IntersectionsData, xml: str, dem: str, gwb_meshe
     fault_output: FaultIntersectionsResult = {
         'forCrossSections': {}, 'forMaps': {}}
 
-    n_points = data['resolution']
-
     get_current_profiler()\
         .set_profiler_metadata('num_series', MetadataHelpers.num_series(model))\
         .set_profiler_metadata('num_units', MetadataHelpers.num_units(model))\
@@ -265,7 +264,7 @@ def compute_intersections(data: IntersectionsData, xml: str, dem: str, gwb_meshe
         .set_profiler_metadata('num_infinite_faults', MetadataHelpers.num_infinite_faults(model))\
         .set_profiler_metadata('num_interfaces', MetadataHelpers.num_interfaces(model, fault=False))\
         .set_profiler_metadata('num_foliations', MetadataHelpers.num_foliations(model, fault=False))\
-        .set_profiler_metadata('resolution', n_points)\
+        .set_profiler_metadata('resolution', data['resolution'])\
         .set_profiler_metadata('num_sections', len(data['toCompute']))\
         .set_profiler_metadata('compute_map', data['computeMap'])\
         .set_profiler_metadata('num_springs', len(data['springs']) if 'springs' in data else 0)\
@@ -283,10 +282,15 @@ def compute_intersections(data: IntersectionsData, xml: str, dem: str, gwb_meshe
                    int(round(rect['upperRight']['z']))]
         max_dist_proj = max(box.xmax - box.xmin, box.ymax -
                             box.ymin) * RATIO_MAX_DIST_PROJ
-        xyz = compute_vertical_slice_points(x_coord, y_coord, z_coord, n_points)
+        x_extent = x_coord[1] - x_coord[0]
+        y_extent = y_coord[1] - y_coord[0]
+        width = math.sqrt(x_extent ** 2 + y_extent ** 2)
+        height = z_coord[1] - z_coord[0]
+        resolution = calculate_resolution(width, height, data['resolution'])
+        xyz = compute_vertical_slice_points(x_coord, y_coord, z_coord, resolution)
         get_current_profiler().profile('cross_section_grid')
 
-        cross_sections[key] = compute_cross_section_ranks(xyz, n_points, model, topography=True)
+        cross_sections[key] = compute_cross_section_ranks(xyz, resolution, model, topography=True)
         if any(key in data for key in ["springs", "drillholes"]) or gwb_meshes:
             lower_left = np.array([x_coord[0], y_coord[0], z_coord[0]])
             upper_right = np.array([x_coord[1], y_coord[1], z_coord[1]])
@@ -294,16 +298,19 @@ def compute_intersections(data: IntersectionsData, xml: str, dem: str, gwb_meshe
                                                                             lower_left, upper_right,
                                                                             xyz, data.get("springs"), data.get("drillholes"),
                                                                             gwb_meshes, max_dist_proj)
-        fault_output['forCrossSections'][key] = compute_fault_intersections(xyz, n_points, model)
+        fault_output['forCrossSections'][key] = compute_fault_intersections(xyz, resolution, model)
 
     mesh_output: MeshIntersectionsResult = {'forCrossSections': cross_sections,
                                             'drillholes': drillhole_lines, 'springs': spring_points, 'matrixGwb': matrix_gwb}
     if data['computeMap']:
-        xyz = compute_map_points(box, n_points, model)
+        width = box.xmax - box.xmin
+        height = box.ymax - box.ymin
+        resolution = calculate_resolution(width, height, data['resolution'])
+        xyz = compute_map_points(box, resolution, model)
         get_current_profiler().profile('map_grid')
 
-        mesh_output['forMaps'] = compute_cross_section_ranks(xyz, n_points, model, topography=False)
-        fault_output['forMaps'] = compute_fault_intersections(xyz, n_points, model)
+        mesh_output['forMaps'] = compute_cross_section_ranks(xyz, resolution, model, topography=False)
+        fault_output['forMaps'] = compute_fault_intersections(xyz, resolution, model)
     get_current_profiler().save_profiler_results()
     return {'mesh': mesh_output, 'fault': fault_output}
 

--- a/geocruncher/computations.py
+++ b/geocruncher/computations.py
@@ -285,7 +285,7 @@ def compute_intersections(data: IntersectionsData, xml: str, dem: str, gwb_meshe
         x_extent = x_coord[1] - x_coord[0]
         y_extent = y_coord[1] - y_coord[0]
         width = math.sqrt(x_extent ** 2 + y_extent ** 2)
-        height = z_coord[1] - z_coord[0]
+        height = abs(z_coord[1] - z_coord[0])
         resolution = calculate_resolution(width, height, data['resolution'])
         xyz = compute_vertical_slice_points(x_coord, y_coord, z_coord, resolution)
         get_current_profiler().profile('cross_section_grid')


### PR DESCRIPTION
See: https://trello.com/c/XwzCVk57/2182-limit-the-intersections-plot-to-the-part-of-the-section-inside-the-project
Companion PR: https://github.com/ISSKA/VISKAR/pull/1558

- Compute intersections at an X/Y resolution corresponding to the ratio of the computed area, instead of a square resolution