### PR TITLE
Use RIGS for generating faults

### DIFF
--- a/docker/Dockerfile.common
+++ b/docker/Dockerfile.common
@@ -29,6 +29,7 @@ RUN pip install \
     flask \
     forgeo \
     forgeo-gmlib \
+    forgeo-rigs \
     lxml \
     meshio \
     numpy \

--- a/geocruncher/MeshGeneration.py
+++ b/geocruncher/MeshGeneration.py
@@ -1,4 +1,5 @@
 import numpy as np
+from collections import defaultdict
 
 from forgeo.gmlib.GeologicalModel3D import GeologicalModel, Box
 
@@ -136,8 +137,13 @@ def generate_rigs_volumes(
     # The biggest par of the job is done here. Convert to rigs data structure and extract surfaces
     v, f, parts, surface_names = extract(model, shape, box)
 
+    # The returned data is one big list of vertices and faces for all parts. We can separate the faces by part using an identifier per face.
+    grouped = defaultdict(list)
+    for i, fi in enumerate(f):
+        grouped[parts[i]].append(fi)
+
     # Then separate the result into the relevant units/faults and generate Draco meshes for each
-    for part in np.unique(parts):
+    for part in grouped.keys():
         try:
             prefixed_name = surface_names[part]
             print(f"Extracting part {part} with name {prefixed_name}")
@@ -146,9 +152,7 @@ def generate_rigs_volumes(
             print(f"Ignoring part {part} with unknown name")
             continue
 
-        # The returned data is one big list of vertices and faces for all parts. We can separate the faces by part using an identifier per face.
-        faces = [fi for i, fi in enumerate(f) if parts[i] == part]
-        mesh = generate_mesh(v, faces)
+        mesh = generate_mesh(v, grouped[part])
 
         # We can know which unit/fault the part represents, as the identifier is the index in surface_names
         # Since units and faults are mixed, we need to figure out which type this is
@@ -183,14 +187,18 @@ def generate_faults_files(
 
     profile_step('tesselate_faults')
 
+    # The returned data is one big list of vertices and faces for all parts. We can separate the faces by part using an identifier per face.
+    grouped = defaultdict(list)
+    for i, fi in enumerate(f):
+        grouped[parts[i]].append(fi)
+
     out_files = {}
-    for part in np.unique(parts):
-        name = surface_names[part]
-        # The returned data is one big list of vertices and faces for all parts. We can separate the faces by part using an identifier per face.
+
+    for part in grouped.keys():
         # We can know which unit/fault the part represents, as the identifier is the index in surface_names
         # Here we only computed faults therefore we assume every returned part is a valid fault. There is a bit more checking if we compute both units & faults
-        faces = [fi for i, fi in enumerate(f) if parts[i] == part]
-        mesh = generate_mesh(v, faces)
+        name = surface_names[part]
+        mesh = generate_mesh(v, grouped[part])
         out_files[name] = mesh
 
     return out_files

--- a/geocruncher/MeshGeneration.py
+++ b/geocruncher/MeshGeneration.py
@@ -2,13 +2,13 @@ import numpy as np
 
 from forgeo.gmlib.GeologicalModel3D import GeologicalModel, Box
 
-from forgeo.gmlib.tesselate import tesselate_faults
 from skimage.measure import marching_cubes
 from forgeo.gmlib.architecture import from_GeoModeller, make_evaluator, grid
 from forgeo.gmlib.utils.tools import BBox3
 
 from .profiler import profile_step
 from .mesh_io.mesh_io import generate_mesh
+from .rigs import extract
 
 
 # Constants
@@ -108,18 +108,89 @@ def generate_volumes(
     return out_files
 
 
+# Currently unused, for future reference and testing. Drop-in replacement for "generate_volumes", but currently returns surfaces and not volumes (not yet implemented in rigs)
+def generate_rigs_volumes(
+    model: GeologicalModel, shape: tuple[int, int, int], box: Box = None
+) -> {"mesh": dict[str, bytes], "fault": dict[str, bytes]}:
+    """Generates topologically valid meshes for each unit in the model. Meshes are output in Draco format.
+
+    Parameters:
+        model: A valid GeologicalModel with a loaded surface model (DEM).
+        shape: Size of the regular grid of tesselated cubes. (x,y,z)
+        box: Custom box. Optional
+    """
+    out_files = {"mesh": {}, "fault": {}}
+    is_top = model.pile.reference == "top"
+
+    # Create a map from unit name to unit id, as we want to return the meshes indexed by this id, but in rigs we identify them through their name
+    unit_names = model.pile_formations
+    unit_id = {}
+    for i, n in enumerate(unit_names):
+        unit_id[n] = i + 1 if is_top else i
+    # Rigs returns units and faults mixed up, so we need to know which faults exist
+    fault_names = list(model.faults.keys())
+
+    # The rigs name is the pile reference dash the unit name
+    prefix = model.pile.reference + "-"
+
+    # The biggest par of the job is done here. Convert to rigs data structure and extract surfaces
+    v, f, parts, surface_names = extract(model, shape, box)
+
+    # Then separate the result into the relevant units/faults and generate Draco meshes for each
+    for part in np.unique(parts):
+        try:
+            prefixed_name = surface_names[part]
+            print(f"Extracting part {part} with name {prefixed_name}")
+        except IndexError:
+            # Can happen when messing with rigs input parameters. should not happen in prod
+            print(f"Ignoring part {part} with unknown name")
+            continue
+
+        # The returned data is one big list of vertices and faces for all parts. We can separate the faces by part using an identifier per face.
+        faces = [fi for i, fi in enumerate(f) if parts[i] == part]
+        mesh = generate_mesh(v, faces)
+
+        # We can know which unit/fault the part represents, as the identifier is the index in surface_names
+        # Since units and faults are mixed, we need to figure out which type this is
+        if prefixed_name in fault_names:
+            # faults are indexed by their name
+            out_files["fault"][prefixed_name] = mesh
+        else:
+            try:
+                # Remove the prefix in order to look up the unit id from the original name
+                name = prefixed_name[len(prefix) :]
+                # Units are indexed by their unit id (sequence based on pile order)
+                out_files["mesh"][str(unit_id[name])] = mesh
+            except KeyError:
+                # The list can also contain "topography", which represents the DEM. We don't want to save that
+                # Can be saved to index 0 for debug, this makes it the dummy mesh
+                # out_files["mesh"][str(0)] = mesh
+                continue
+
+    return out_files
+
+
 def generate_faults_files(
     model: GeologicalModel, shape: tuple[int, int, int], box: Box = None
 ) -> dict[str, bytes]:
-    box = box or model.getbox()
-    faults = tesselate_faults(box, shape, model)
+    # For now, the resolution of faults is 10x lower than the mesh, with a minimum of 10, as with RIGS, we see no improvements with increased resolution except for conformity with the DEM and higher resolutions are extremely slow
+    rigs_shape = (
+        int(max(10, shape[0] / 10)),
+        int(max(10, shape[1] / 10)),
+        int(max(10, shape[2] / 10)),
+    )
+    v, f, parts, surface_names = extract(model, rigs_shape, box, faults_only=True)
 
     profile_step('tesselate_faults')
 
     out_files = {}
-    for name, fault in faults.items():
-        if not fault.is_empty():
-            fault_arr = fault.as_arrays()
-            out_files[name] = generate_mesh(fault_arr[0], fault_arr[1][0])
-            profile_step('generate_mesh')
+    for part in np.unique(parts):
+        name = surface_names[part]
+        # The returned data is one big list of vertices and faces for all parts. We can separate the faces by part using an identifier per face.
+        # We can know which unit/fault the part represents, as the identifier is the index in surface_names
+        # Here we only computed faults therefore we assume every returned part is a valid fault. There is a bit more checking if we compute both units & faults
+        faces = [fi for i, fi in enumerate(f) if parts[i] == part]
+        mesh = generate_mesh(v, faces)
+        out_files[name] = mesh
+
     return out_files

--- a/geocruncher/mesh_io/draco.py
+++ b/geocruncher/mesh_io/draco.py
@@ -6,10 +6,52 @@ DRACO_COMPRESSION_LEVEL = 6
 DRACO_QUANTIZATION_BITS = 14
 
 
+def triangulate_faces(faces):
+    """
+    Convert mixed triangles, quads, and ngons to all triangles.
+    Uses fan triangulation for ngons.
+
+    Args:
+        faces: List of faces, each being a list of vertex indices
+
+    Returns:
+        numpy array of triangles with shape (N, 3)
+    """
+    triangles = []
+
+    for face in faces:
+        n_verts = len(face)
+
+        if n_verts == 3:
+            # Triangle - keep as is
+            triangles.append(face)
+
+        elif n_verts == 4:
+            # Quad - split into two triangles
+            triangles.append([face[0], face[1], face[2]])
+            triangles.append([face[0], face[2], face[3]])
+
+        elif n_verts >= 5:
+            # Ngon - fan triangulation around first vertex
+            # Creates triangles: (0,1,2), (0,2,3), (0,3,4), ...
+            for i in range(1, n_verts - 1):
+                triangles.append([face[0], face[i], face[i + 1]])
+
+        else:
+            raise ValueError(
+                f"Invalid face with {n_verts} vertices (minimum 3 required)"
+            )
+
+    return np.array(triangles, dtype=np.int32)
+
+
 def generate_draco(verts: np.array, faces: np.array) -> bytes:
-    return DracoPy.encode(verts, faces,
-                          quantization_bits=DRACO_QUANTIZATION_BITS,
-                          compression_level=DRACO_COMPRESSION_LEVEL)
+    return DracoPy.encode(
+        verts,
+        triangulate_faces(faces),
+        quantization_bits=DRACO_QUANTIZATION_BITS,
+        compression_level=DRACO_COMPRESSION_LEVEL,
+    )
 
 
 def read_draco_to_polydata(draco_bytes: bytes) -> pv.PolyData:

--- a/geocruncher/mesh_io/draco.py
+++ b/geocruncher/mesh_io/draco.py
@@ -6,16 +6,16 @@ DRACO_COMPRESSION_LEVEL = 6
 DRACO_QUANTIZATION_BITS = 14
 
 
-def triangulate_faces(faces):
+def triangulate_faces(faces: list) -> np.ndarray:
     """
     Convert mixed triangles, quads, and ngons to all triangles.
     Uses fan triangulation for ngons.
 
     Args:
-        faces: List of faces, each being a list of vertex indices
+        faces: np.array of faces, each being a list of vertex indices
 
     Returns:
-        numpy array of triangles with shape (N, 3)
+        np.array of triangles with shape (N, 3)
     """
     triangles = []
 
@@ -45,10 +45,16 @@ def triangulate_faces(faces):
     return np.array(triangles, dtype=np.int32)
 
 
-def generate_draco(verts: np.array, faces: np.array) -> bytes:
+def generate_draco(verts: np.ndarray | list, faces: np.ndarray | list) -> bytes:
+    # numpy array have homogeneous shapes, so check if it is an numpy array of correct shape. otherwise assume not and triangulate
+    f = (
+        faces
+        if isinstance(faces, np.ndarray) and faces.shape[1] == 3
+        else triangulate_faces(faces)
+    )
     return DracoPy.encode(
         verts,
-        triangulate_faces(faces),
+        f,
         quantization_bits=DRACO_QUANTIZATION_BITS,
         compression_level=DRACO_COMPRESSION_LEVEL,
     )

--- a/geocruncher/mesh_io/mesh_io.py
+++ b/geocruncher/mesh_io/mesh_io.py
@@ -10,7 +10,9 @@ def is_off_file(data: bytes) -> bool:
     return len(data) >= 3 and data[:3] == b"OFF"
 
 
-def generate_mesh(verts: np.array, faces: np.array, use_off=False) -> bytes:
+def generate_mesh(
+    verts: np.ndarray | list, faces: np.ndarray | list, use_off=False
+) -> bytes:
     if use_off:
         return generate_off(verts, faces)
     else:

--- a/geocruncher/mesh_io/off.py
+++ b/geocruncher/mesh_io/off.py
@@ -56,7 +56,7 @@ def read_off(string: str) -> Mesh:
     return Mesh(verts, cells)
 
 
-def generate_off(verts: np.array, faces: np.array, precision=3):
+def generate_off(verts: np.ndarray | list, faces: np.ndarray | list, precision=3):
     """Generates a valid OFF string from the given verts and faces.
 
     Parameters
@@ -78,7 +78,7 @@ def generate_off(verts: np.array, faces: np.array, precision=3):
     num_verts = len(verts)
     num_faces = len(faces)
 
-    verts_rounded = np.round(verts.astype(float), precision)
+    verts_rounded = np.round(np.asarray(verts, dtype=np.float64), precision)
     verts_str = '\n'.join(' '.join(map(str, vertex)) for vertex in verts_rounded)
     faces_str = '\n'.join(f"{len(face)} {' '.join(map(str, face))}" for face in faces)
     return f"OFF\n{num_verts} {num_faces} 0\n{verts_str}\n{faces_str}\n"

--- a/geocruncher/rigs.py
+++ b/geocruncher/rigs.py
@@ -10,7 +10,7 @@ def extract(
     shape: tuple[int, int, int],
     box: Box = None,
     faults_only=False,
-) -> tuple[list, list, list, list[str]]:
+) -> tuple[list, list, list, list]:
     """Generate a regular grid of tesselated cubes, convert the model to RIGS and evaluate it on the grid, returning surfaces
 
     Returns vertices, faces, parts and surface_names
@@ -23,6 +23,13 @@ def extract(
         shape: Size of the regular grid of tesselated cubes. (x,y,z)
         box: Custom box. Optional
         faults_only: If True, only faults will be computed and returned. Defaults to False
+
+    Returns:
+        Tuple[list, list, list, list]: (vertices, faces, parts, surface_names)
+        1) 3d points representing mesh vertices
+        2) references to vertices that form polygons (tris, quads & ngons possible)
+        3) index in surface_names for each face, to determine to which surface it belongs
+        4) the list of surfaces that might be present in the output
     """
 
     box = model.getbox() if box is None else box

--- a/geocruncher/rigs.py
+++ b/geocruncher/rigs.py
@@ -1,0 +1,43 @@
+from forgeo.gmlib.GeologicalModel3D import GeologicalModel, Box
+from forgeo.rigs import all_intersections
+from forgeo.rigs.tetcube import tetgrid
+from forgeo.rigs.gmconverter import convert
+
+
+# TODO: more accurate typings for the returned values
+def extract(
+    model: GeologicalModel,
+    shape: tuple[int, int, int],
+    box: Box = None,
+    faults_only=False,
+) -> tuple[list, list, list, list[str]]:
+    """Generate a regular grid of tesselated cubes, convert the model to RIGS and evaluate it on the grid, returning surfaces
+
+    Returns vertices, faces, parts and surface_names
+    You can determine to which part each face belongs with the third return value (parts). For each face, it is an index in the forth return value (surface_names), which corresponds to units, faults, and the "topography"
+
+    The returned unit names are prefixed with the pile reference and a dash (ex: "base-Molasse")
+
+    Parameters:
+        model: A valid GeologicalModel with a loaded surface model (DEM).
+        shape: Size of the regular grid of tesselated cubes. (x,y,z)
+        box: Custom box. Optional
+        faults_only: If True, only faults will be computed and returned. Defaults to False
+    """
+
+    box = model.getbox() if box is None else box
+    vertices, cells = tetgrid(
+        shape,
+        extent=(box.xmin, box.xmax, box.ymin, box.ymax, box.zmin, box.zmax),
+    )
+
+    params = convert(model, with_topography=True, faults_only=faults_only)
+    results = all_intersections(vertices, cells, **params, return_iso_surfaces=True)
+
+    iso = results.iso_surfaces
+    return (
+        iso.vertices,
+        iso.faces,
+        iso.color,
+        params["names"],
+    )


### PR DESCRIPTION
This is a first integration of the RIGS library. At the moment, it can only generate surfaces, therefore it was used to replace the old and slow faults generation code. Results are basically identical to the old GMLIB code, at a much lower computation cost.

Other included changes:
- Triangulate meshes before generating Draco files (required since Draco only handles triangles, and RIGS might return any polygons)
- Add unused method to compute mesh surfaces with RIGS (instead of volumes. for reference/testing)