### PR TITLE
Polling metadata

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -2,7 +2,7 @@ import json
 import tarfile
 from io import BytesIO
 
-from celery.result import AsyncResult
+from celery.result import AsyncResult, states
 from flask import Flask, Response, request, send_file
 from pydantic import TypeAdapter, ValidationError
 
@@ -41,6 +41,18 @@ def filemap_to_tar(files: dict[bytes, bytes]) -> BytesIO:
     output.seek(0)
     return output
 
+def non_success_response(res: AsyncResult) -> Response | None:
+    """Returns a Response if the state is not SUCCESS, otherwise None.
+    Additionally, cleans up task result if state is FAILURE or REVOKED"""
+    state = res.state
+    if state == states.SUCCESS:
+        return None
+
+    if state in {states.FAILURE, states.REVOKED}:
+        res.forget()
+
+    return Response(state, mimetype="text/plain")
+
 
 def compute_meshes_or_faults(is_meshes: bool):
     if request.method == "POST":
@@ -72,9 +84,9 @@ def compute_meshes_or_faults(is_meshes: bool):
         if _id is None or _id == "":
             return Response("Missing parameter id", 400, mimetype="text/plain")
         res = AsyncResult(_id)
-        if res.state != "SUCCESS":
-            res.forget()
-            return Response(res.state, mimetype="text/plain")
+        response = non_success_response(res)
+        if response is not None:
+            return response
         # TODO: catch errors
         output_key = res.get()
         meshes = get_hash_bytes(r, output_key)
@@ -111,9 +123,9 @@ def compute_tunnel_meshes():
         if _id is None or _id == "":
             return Response("Missing parameter id", 400, mimetype="text/plain")
         res = AsyncResult(_id)
-        if res.state != "SUCCESS":
-            res.forget()
-            return Response(res.state, mimetype="text/plain")
+        response = non_success_response(res)
+        if response is not None:
+            return response
         # TODO: catch errors
         output_key = res.get()
         meshes = get_hash_bytes(r, output_key)
@@ -176,9 +188,9 @@ def compute_intersections():
         if _id is None or _id == "":
             return Response("Missing parameter id", 400, mimetype="text/plain")
         res = AsyncResult(_id)
-        if res.state != "SUCCESS":
-            res.forget()
-            return Response(res.state, mimetype="text/plain")
+        response = non_success_response(res)
+        if response is not None:
+            return response
         # TODO: catch errors
         output_key = res.get()
         output = get_bytes(r, output_key)
@@ -231,9 +243,9 @@ def compute_voxels():
         if _id is None or _id == "":
             return Response("Missing parameter id", 400, mimetype="text/plain")
         res = AsyncResult(_id)
-        if res.state != "SUCCESS":
-            res.forget()
-            return Response(res.state, mimetype="text/plain")
+        response = non_success_response(res)
+        if response is not None:
+            return response
         # TODO: catch errors
         output_key = res.get()
         mesh = get_bytes(r, output_key)
@@ -268,9 +280,9 @@ def compute_gwb_meshes():
         if _id is None or _id == "":
             return Response("Missing parameter id", 400, mimetype="text/plain")
         res = AsyncResult(_id)
-        if res.state != "SUCCESS":
-            res.forget()
-            return Response(res.state, mimetype="text/plain")
+        response = non_success_response(res)
+        if response is not None:
+            return response
         # TODO: catch errors
         output_key = res.get()
         meshes_and_metadata = get_hash_bytes(r, output_key)
@@ -313,7 +325,7 @@ def revoke():
 
     res = AsyncResult(_id)
     res.revoke(terminate=True, wait=True, timeout=2)
-    if res.state != "REVOKED":
+    if res.state != states.REVOKED:
         return Response(f"Task {_id} could not be revoked", 500, mimetype="text/plain")
     else:
         return Response(f"Task {_id} revoked", 200, mimetype="text/plain")

--- a/api/api.py
+++ b/api/api.py
@@ -2,6 +2,7 @@ import json
 import tarfile
 from io import BytesIO
 
+from celery.result import AsyncResult
 from flask import Flask, Response, request, send_file
 from pydantic import TypeAdapter, ValidationError
 
@@ -13,7 +14,6 @@ from geocruncher.computations import (
 )
 
 from . import tasks
-from .celery import app as celery
 from .redis import redis_client as r
 from .utils import (
     generate_key,
@@ -71,8 +71,9 @@ def compute_meshes_or_faults(is_meshes: bool):
         _id = request.args.get("id")
         if _id is None or _id == "":
             return Response("Missing parameter id", 400, mimetype="text/plain")
-        res = celery.AsyncResult(_id)
+        res = AsyncResult(_id)
         if res.state != "SUCCESS":
+            res.forget()
             return Response(res.state, mimetype="text/plain")
         # TODO: catch errors
         output_key = res.get()
@@ -109,8 +110,9 @@ def compute_tunnel_meshes():
         _id = request.args.get("id")
         if _id is None or _id == "":
             return Response("Missing parameter id", 400, mimetype="text/plain")
-        res = celery.AsyncResult(_id)
+        res = AsyncResult(_id)
         if res.state != "SUCCESS":
+            res.forget()
             return Response(res.state, mimetype="text/plain")
         # TODO: catch errors
         output_key = res.get()
@@ -173,8 +175,9 @@ def compute_intersections():
         _id = request.args.get("id")
         if _id is None or _id == "":
             return Response("Missing parameter id", 400, mimetype="text/plain")
-        res = celery.AsyncResult(_id)
+        res = AsyncResult(_id)
         if res.state != "SUCCESS":
+            res.forget()
             return Response(res.state, mimetype="text/plain")
         # TODO: catch errors
         output_key = res.get()
@@ -227,8 +230,9 @@ def compute_voxels():
         _id = request.args.get("id")
         if _id is None or _id == "":
             return Response("Missing parameter id", 400, mimetype="text/plain")
-        res = celery.AsyncResult(_id)
+        res = AsyncResult(_id)
         if res.state != "SUCCESS":
+            res.forget()
             return Response(res.state, mimetype="text/plain")
         # TODO: catch errors
         output_key = res.get()
@@ -263,8 +267,9 @@ def compute_gwb_meshes():
         _id = request.args.get("id")
         if _id is None or _id == "":
             return Response("Missing parameter id", 400, mimetype="text/plain")
-        res = celery.AsyncResult(_id)
+        res = AsyncResult(_id)
         if res.state != "SUCCESS":
+            res.forget()
             return Response(res.state, mimetype="text/plain")
         # TODO: catch errors
         output_key = res.get()
@@ -288,8 +293,12 @@ def poll():
     data = request.json
     result = {}
     for _id in data:
-        res = celery.AsyncResult(str(_id))
-        result[str(_id)] = res.state
+        res = AsyncResult(str(_id))
+        meta = res._get_task_meta()["result"]
+        result[str(_id)] = {
+            "state": res.state,
+            "progress": meta if isinstance(meta, dict) else None,
+        }
     return Response(
         json.dumps(result, separators=(",", ":")), mimetype="application/json"
     )
@@ -302,7 +311,7 @@ def revoke():
     if not _id or _id == "":
         return Response("Missing parameter id", 400, mimetype="text/plain")
 
-    res = celery.AsyncResult(_id)
+    res = AsyncResult(_id)
     res.revoke(terminate=True, wait=True, timeout=2)
     if res.state != "REVOKED":
         return Response(f"Task {_id} could not be revoked", 500, mimetype="text/plain")

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -1,34 +1,41 @@
 import json
 from collections import defaultdict
 
+from celery import Task
+
 from geocruncher import computations
 from geocruncher.profiler import ProfilerMetadata
+from geocruncher.profiler.profiler import set_current_task
 
 from .celery import app
 from .redis import redis_client as r
 from .utils import get_and_delete, get_hash_bytes, hset_bytes
 
 
-@app.task
+@app.task(bind=True)
 def compute_tunnel_meshes(
+    self: Task,
     data: computations.TunnelMeshesData,
     output_key: str,
     metadata: ProfilerMetadata | None = None,
 ) -> str:
+    set_current_task(self)
     meshes = computations.compute_tunnel_meshes(data, metadata)
     for field, value in meshes.items():
         hset_bytes(r, output_key, field, value)
     return output_key
 
 
-@app.task
+@app.task(bind=True)
 def compute_meshes(
+    self: Task,
     data: computations.MeshesData,
     xml_key: str,
     dem_key: str,
     output_key: str,
     metadata: ProfilerMetadata | None = None,
 ) -> str:
+    set_current_task(self)
     xml = get_and_delete(r, xml_key)
     dem = get_and_delete(r, dem_key).decode("utf-8")
 
@@ -46,8 +53,9 @@ def compute_meshes(
     return output_key
 
 
-@app.task
+@app.task(bind=True)
 def compute_intersections(
+    self: Task,
     data: computations.IntersectionsData,
     xml_key: str,
     dem_key: str,
@@ -55,6 +63,7 @@ def compute_intersections(
     output_key: str,
     metadata: ProfilerMetadata | None = None,
 ) -> str:
+    set_current_task(self)
     xml = get_and_delete(r, xml_key)
     dem = get_and_delete(r, dem_key).decode("utf-8")
 
@@ -73,14 +82,16 @@ def compute_intersections(
     return output_key
 
 
-@app.task
+@app.task(bind=True)
 def compute_faults(
+    self: Task,
     data: computations.MeshesData,
     xml_key: str,
     dem_key: str,
     output_key: str,
     metadata: ProfilerMetadata | None = None,
 ) -> str:
+    set_current_task(self)
     xml = get_and_delete(r, xml_key)
     dem = get_and_delete(r, dem_key).decode("utf-8")
 
@@ -93,8 +104,9 @@ def compute_faults(
     return output_key
 
 
-@app.task
+@app.task(bind=True)
 def compute_voxels(
+    self: Task,
     data: computations.MeshesData,
     xml_key: str,
     dem_key: str,
@@ -102,6 +114,7 @@ def compute_voxels(
     output_key: str,
     metadata: ProfilerMetadata | None = None,
 ) -> str:
+    set_current_task(self)
     xml = get_and_delete(r, xml_key)
     dem = get_and_delete(r, dem_key).decode("utf-8")
 
@@ -118,14 +131,15 @@ def compute_voxels(
     return output_key
 
 
-@app.task
+@app.task(bind=True)
 def compute_gwb_meshes(
+    self: Task,
     data: list[computations.Spring],
     meshes_key: str,
     output_key: str,
     metadata: ProfilerMetadata | None = None,
 ) -> str:
-
+    set_current_task(self)
     # get existing meshes for groundwater bodies
     unit_meshes: dict[str, bytes] = {}
     stored = get_hash_bytes(r, meshes_key)

--- a/geocruncher/computations.py
+++ b/geocruncher/computations.py
@@ -10,6 +10,8 @@ from typing import NotRequired, TypedDict, cast
 import numpy as np
 from forgeo.gmlib.GeologicalModel3D import Box, GeologicalModel
 
+from geocruncher.profiler.profiler import start_step
+
 from .compute_intersections import (
     calculate_resolution,
     compute_cross_section_ranks,
@@ -187,6 +189,7 @@ def compute_meshes(
         Dictionnary with mesh, a map from unit ID to OFF or Draco mesh file, and fault, a map from fault name to OFF or Draco mesh file.
     """
     profiler = set_profiler(PROFILES["meshes"])
+    start_step("load_model")
     model = GeologicalModel(extract_project_data(xml, dem), use_cache=False)
 
     shape = (data["resolution"]["x"], data["resolution"]["y"], data["resolution"]["z"])

--- a/geocruncher/computations.py
+++ b/geocruncher/computations.py
@@ -315,6 +315,7 @@ def compute_intersections(
         TODO: find a more complete explanation of what is returned and simplify return type.
     """
     profiler = set_profiler(PROFILES["intersections"])
+    start_step("load_model")
     model = GeologicalModel(extract_project_data(xml, dem), use_cache=False)
     box = model.getbox()
     max_dist_proj = max(box.xmax - box.xmin, box.ymax - box.ymin) * RATIO_MAX_DIST_PROJ
@@ -362,6 +363,7 @@ def compute_intersections(
         mesh_output["matrixGwb"][key] = []
 
         for b in intersection:
+            start_step("cross_section_grid")
             b = Box(**b)
             # FIXME: if we remove rounding, it breaks virtual drillhole slices. But it feels wrong to round, since we are rounding to arbitrary units of EPSG, usually meters, and the effect is not going to be the same on small and large projects
             x_coord = (round(b.xmin), round(b.xmax))
@@ -406,6 +408,7 @@ def compute_intersections(
             )
 
     if data["computeMap"]:
+        start_step("map_grid")
         width = box.xmax - box.xmin
         height = box.ymax - box.ymin
         resolution = calculate_resolution(width, height, data["resolution"])
@@ -445,6 +448,7 @@ def compute_faults(
         Dictionnary with mesh, an empty map, and fault, a map from fault name to OFF mesh file.
     """
     profiler = set_profiler(PROFILES["faults"])
+    start_step("load_model")
     model = GeologicalModel(extract_project_data(xml, dem), use_cache=False)
 
     shape = (data["resolution"]["x"], data["resolution"]["y"], data["resolution"]["z"])
@@ -503,6 +507,7 @@ def compute_voxels(
         The VOX mesh file
     """
     profiler = set_profiler(PROFILES["voxels"])
+    start_step("load_model")
     model = GeologicalModel(extract_project_data(xml, dem), use_cache=False)
 
     shape = (data["resolution"]["x"], data["resolution"]["y"], data["resolution"]["z"])

--- a/geocruncher/compute_intersections.py
+++ b/geocruncher/compute_intersections.py
@@ -11,7 +11,7 @@ from forgeo.gmlib.architecture import (
 from forgeo.gmlib.GeologicalModel3D import Box, GeologicalModel
 
 from .mesh_io.mesh_io import read_mesh_to_polydata
-from .profiler import profile_step
+from .profiler import profile_step, start_step
 
 
 def calculate_resolution(width: float, height: float, res: int) -> tuple[int, int]:
@@ -151,7 +151,7 @@ def compute_cross_section_ranks(
     -----
     For top-down views the topography should be False and for vertical slices it should be True.
     """
-
+    start_step("ranks")
     cppmodel = from_GeoModeller(model)
     if topography:
         topography = model.implicit_topography()
@@ -207,7 +207,7 @@ def project_hydro_features_on_slice(
         List of groundwater body values for each point in rank_matrix
         each value corresponds to the groundwater body ID for that point
     """
-
+    start_step("hydro_setup")
     # Create a third point to define the plane
     # The third point is the same x and y as the lower left corner, but z is the upper right corner
     # This is possible because cross sections are always parallel to the z axis
@@ -261,6 +261,7 @@ def project_hydro_features_on_slice(
     springs_point = {}
     profile_step("hydro_setup")
 
+    start_step("hydro_project_drillholes")
     if drillhole_map:
         for d_id, line in drillhole_map.items():
             line = Box(**line)
@@ -274,6 +275,7 @@ def project_hydro_features_on_slice(
                 drillholes_line[d_id] = [s_proj, e_proj]
     profile_step("hydro_project_drillholes")
 
+    start_step("hydro_project_springs")
     if spring_map:
         for s_id, p in spring_map.items():
             point = np.array([p["x"], p["y"], p["z"]])
@@ -282,6 +284,7 @@ def project_hydro_features_on_slice(
                 springs_point[s_id] = p_proj
     profile_step("hydro_project_springs")
 
+    start_step(step="hydro_project_gwbs")
     points_polydata = pv.PolyData(xyz)
     # Test each point of the cross section against groundwater body meshes
     for gwb_id, meshes in gwb_meshes.items():

--- a/geocruncher/fault_intersections.py
+++ b/geocruncher/fault_intersections.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import numpy as np
 from forgeo.gmlib.GeologicalModel3D import GeologicalModel
 
-from .profiler import profile_step
+from .profiler import profile_step, start_step
 
 CLIP_VALUE = np.nan
 
@@ -60,6 +60,7 @@ class FaultIntersector:
         return topography
 
     def intersect(self) -> dict:
+        start_step("tesselate_faults")
         res = self._resolution
         topography_2d = self._topography.reshape(res)
 

--- a/geocruncher/geo_algo.py
+++ b/geocruncher/geo_algo.py
@@ -6,7 +6,7 @@ from typing import TypedDict
 
 import PyGeoAlgo as ga
 
-from .profiler import profile_step
+from .profiler import profile_step, start_step
 
 
 class GwbMeshesResult(TypedDict):
@@ -30,6 +30,7 @@ class GeoAlgoOutput(TypedDict):
 class GeoAlgo:
     @staticmethod
     def output(unit_meshes: dict[str, bytes], springs: list) -> GeoAlgoOutput:
+        start_step("load_mesh")
         s = [
             ga.Spring(
                 spring["id"],
@@ -49,10 +50,12 @@ class GeoAlgo:
         ]
         profile_step("load_mesh")
 
+        start_step("compute")
         aquifer_calc = ga.AquiferCalc(m, s)
         aquifers = aquifer_calc.calculate()
         profile_step("compute")
 
+        start_step("generate_mesh")
         metadata = []
         meshes = []
         for aquifer in aquifers:

--- a/geocruncher/mesh_generation.py
+++ b/geocruncher/mesh_generation.py
@@ -11,7 +11,7 @@ from forgeo.gmlib.utils.tools import BBox3
 from skimage.measure import marching_cubes
 
 from .mesh_io.mesh_io import generate_mesh
-from .profiler import profile_step
+from .profiler import profile_step, start_step
 from .rigs import extract
 
 # Constants
@@ -60,6 +60,9 @@ def generate_volumes(
         shape: Number of samples for marching cubes (x,y,z)
         box: Custom box
     """
+
+    start_step("ranks")
+
     ranks = compute_ranks(shape, model, box)
     ranks.shape = shape
 
@@ -81,6 +84,7 @@ def generate_volumes(
     extended_shape = tuple(n + 2 for n in shape)
 
     for rank in rank_values:
+        start_step("volume")
         if rank == RANK_SKY:
             continue
         if model.pile.reference == "base":
@@ -96,6 +100,7 @@ def generate_volumes(
 
         profile_step("volume")
 
+        start_step("marching_cubes")
         # Using the lewiner variant leads to holes in the meshes which CGAL cannot handle
         # (Produces an error when reading the OFF in geo-algo/VK-Aquifers)
         # Gradient direction ensures normals point outwards. Otherwise, aquifers computation will be incorrect
@@ -105,6 +110,7 @@ def generate_volumes(
         scaled_verts = rescale_to_grid(verts, box, shape)
         profile_step("marching_cubes")
 
+        start_step("generate_mesh")
         mesh = generate_mesh(scaled_verts, faces)
         out_files["mesh"][str(rank_id)] = mesh
         profile_step("generate_mesh")
@@ -185,6 +191,7 @@ def generate_rigs_volumes(
 def generate_faults_files(
     model: GeologicalModel, shape: tuple[int, int, int], box: Box | None = None
 ) -> dict[str, bytes]:
+    start_step("tesselate_faults")
     # For now, the resolution of faults is 10x lower than the mesh, with a minimum of 10, as with RIGS, we see no improvements with increased resolution except for conformity with the DEM and higher resolutions are extremely slow
     rigs_shape = (
         int(max(10, shape[0] / 10)),
@@ -194,6 +201,7 @@ def generate_faults_files(
     v, f, parts, surface_names = extract(model, rigs_shape, box, faults_only=True)
 
     profile_step("tesselate_faults")
+    start_step("generate_mesh")
 
     # The returned data is one big list of vertices and faces for all parts. We can separate the faces by part using an identifier per face.
     grouped = defaultdict(list)

--- a/geocruncher/profiler/__init__.py
+++ b/geocruncher/profiler/__init__.py
@@ -3,6 +3,7 @@ from .profiler import (
     get_current_profiler,
     profile_step,
     set_profiler,
+    start_step,
 )
 from .settings.faults import PROFILER_FAULTS_V5
 from .settings.gwb_meshes import PROFILER_GWB_MESHES_V3
@@ -28,5 +29,6 @@ __all__ = [
     "set_profiler",
     "get_current_profiler",
     "profile_step",
+    "start_step",
     "PROFILES",
 ]

--- a/geocruncher/profiler/profiler.py
+++ b/geocruncher/profiler/profiler.py
@@ -1,5 +1,5 @@
-import datetime
 import time
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 from celery import Task
@@ -26,7 +26,7 @@ class VkProfiler:
         self._metadata: dict[str, Any] = {}
 
         # set the metadata that's on every computation
-        self.set_metadata("start_time", datetime.datetime.now().isoformat())
+        self.set_metadata("start_time", datetime.now().isoformat())
 
     def profile(self, step: str) -> "VkProfiler":
         """Profile a step by name. To be called when the step in question is done.
@@ -118,9 +118,9 @@ def set_current_task(task: Task) -> None:
 
 
 def start_step(step: str) -> None:
-    start_time = int(datetime.datetime.now().timestamp())
-    total_time: float = 0.0
+    start_time = int(datetime.now(timezone.utc).timestamp() * 1000)
+    total_time: int = 0
     profiler = _profiler_manager.get_current_profiler()
     if profiler:
-        total_time = float(profiler._steps[step]["time"])
+        total_time = int(profiler._steps[step]["time"] * 1000)
     _progress_recorder.set_progress(step, start_time, total_time)

--- a/geocruncher/profiler/profiler.py
+++ b/geocruncher/profiler/profiler.py
@@ -2,7 +2,10 @@ import datetime
 import time
 from typing import Any, Optional
 
+from celery import Task
+
 from .config import ProfilerConfig
+from .progress import ProgressRecorder
 from .storage import ProfilerStorage
 from .util import ProfilerMetadata, VkProfilerSettings
 
@@ -86,8 +89,9 @@ class ProfilerManager:
         return self._current_profiler
 
 
-# Global profiler manager instance
+# Global profiler manager & progress recorder instances
 _profiler_manager = ProfilerManager()
+_progress_recorder = ProgressRecorder()
 
 # Public API
 
@@ -107,3 +111,16 @@ def profile_step(step: str) -> None:
     profiler = get_current_profiler()
     if profiler:
         profiler.profile(step)
+
+
+def set_current_task(task: Task) -> None:
+    _progress_recorder.set_current_task(task)
+
+
+def start_step(step: str) -> None:
+    start_time = int(datetime.datetime.now().timestamp())
+    total_time: float = 0.0
+    profiler = _profiler_manager.get_current_profiler()
+    if profiler:
+        total_time = float(profiler._steps[step]["time"])
+    _progress_recorder.set_progress(step, start_time, total_time)

--- a/geocruncher/profiler/progress.py
+++ b/geocruncher/profiler/progress.py
@@ -5,7 +5,8 @@ from celery.result import AsyncResult
 
 
 class ProgressRecorder:
-    task: Optional[Task]
+    def __init__(self) -> None:
+        self.task: Optional[Task] = None
 
     def set_current_task(self, task: Task) -> None:
         self.task = task

--- a/geocruncher/profiler/progress.py
+++ b/geocruncher/profiler/progress.py
@@ -1,0 +1,29 @@
+from typing import Optional
+
+from celery import Task
+from celery.result import AsyncResult
+
+
+class ProgressRecorder:
+    task: Optional[Task]
+
+    def set_current_task(self, task: Task) -> None:
+        self.task = task
+
+    def set_progress(
+        self, current_step: str, start_time: int, total_time: float
+    ) -> None:
+        if self.task is None:
+            return
+        state = AsyncResult(self.task.request.id).state
+        if state != "STARTED":
+            return
+        # The meta object matches VISKAR's JobProgress class
+        self.task.update_state(
+            state=state,
+            meta={
+                "currentStep": current_step,
+                "startTime": start_time,
+                "totalTime": total_time,
+            },
+        )

--- a/geocruncher/profiler/progress.py
+++ b/geocruncher/profiler/progress.py
@@ -10,9 +10,7 @@ class ProgressRecorder:
     def set_current_task(self, task: Task) -> None:
         self.task = task
 
-    def set_progress(
-        self, current_step: str, start_time: int, total_time: float
-    ) -> None:
+    def set_progress(self, current_step: str, start_time: int, total_time: int) -> None:
         if self.task is None:
             return
         state = AsyncResult(self.task.request.id).state

--- a/geocruncher/tunnel_shape_generation.py
+++ b/geocruncher/tunnel_shape_generation.py
@@ -6,7 +6,7 @@ from sympy import diff, symbols
 from sympy.parsing.sympy_parser import parse_expr
 
 from .mesh_io.mesh_io import generate_mesh
-from .profiler import profile_step
+from .profiler import profile_step, start_step
 
 
 def tunnel_to_meshes(
@@ -28,6 +28,7 @@ def tunnel_to_meshes(
         idxStart if idxStart != -1 else 0,
         idxEnd + 1 if idxEnd != -1 else len(functions),
     ):
+        start_step("sympy_parse_diff_function")
         f = functions[j]
         fx = parse_expr(f["x"].replace("^", "**"))
         dfx = diff(fx, t)
@@ -39,6 +40,7 @@ def tunnel_to_meshes(
         for i in np.arange(
             tStart if j == idxStart else 0.0, tEnd if j == idxEnd else 1.0, step
         ):
+            start_step("interpolate_function")
             normal = np.array(
                 [float(dfx.subs(t, i)), float(dfy.subs(t, i)), float(dfz.subs(t, i))]
             )
@@ -46,12 +48,15 @@ def tunnel_to_meshes(
                 [float(fx.subs(t, i)), float(fy.subs(t, i)), float(fz.subs(t, i))]
             )
             profile_step("interpolate_function")
+            start_step("project_points")
             for p in _project_points(normal, bottom, xy_points):
                 vertices.append(p)
             nb_series += 1
             profile_step("project_points")
+    start_step("connect_vertices")
     triangles = _connect_vertices(len(xy_points), nb_series)
     profile_step("connect_vertices")
+    start_step("generate_mesh")
     mesh = generate_mesh(np.array(vertices), np.array(triangles))
     profile_step("generate_mesh")
     return mesh

--- a/geocruncher/voxel_computation.py
+++ b/geocruncher/voxel_computation.py
@@ -7,7 +7,7 @@ from forgeo.gmlib.architecture import (
 from forgeo.gmlib.GeologicalModel3D import Box, GeologicalModel
 
 from .mesh_io.mesh_io import read_mesh_to_polydata
-from .profiler import profile_step
+from .profiler import profile_step, start_step
 
 
 class Voxels:
@@ -18,6 +18,7 @@ class Voxels:
         box: Box,
         gwb_meshes: dict[str, list[bytes]],
     ) -> str:
+        start_step("grid")
         # we use numpy meshgrid to produce a regular grid
         # the output is a list containing a 3D array for each coordinate
         # if we want an evaluation on the center of the voxels
@@ -42,10 +43,12 @@ class Voxels:
         gwb_tags = [0] * xyz.shape[0]
         for gwb_id, meshes in gwb_meshes.items():
             for mesh_data in meshes:
+                start_step("read_gwbs")
                 mesh = read_mesh_to_polydata(mesh_data)
                 points = pv.PolyData(xyz)
                 profile_step("read_gwbs")
 
+                start_step("test_inside_gwbs")
                 inside_points = points.select_enclosed_points(mesh, tolerance=0.00001)
                 selected_points = inside_points["SelectedPoints"].astype(
                     np.uint16
@@ -56,12 +59,14 @@ class Voxels:
                 ]
                 profile_step("test_inside_gwbs")
 
+        start_step("ranks")
         cppmodel = from_GeoModeller(model)
         topography = model.implicit_topography()
         evaluator = make_evaluator(cppmodel, topography)
         ranks = evaluator(xyz)
         profile_step("ranks")
 
+        start_step("generate_vox")
         ranks_tags = list(zip(ranks, gwb_tags))
 
         # We sort the arrays in reverse-nested loop order where z is the outer loop, y the middle and x the inner loop

--- a/scripts/api-local.sh
+++ b/scripts/api-local.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Running as a module will use the Flask dev server, running on port 5000
-python -m api
+uv run api

--- a/scripts/worker-local.sh
+++ b/scripts/worker-local.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A api worker -l INFO -Q geocruncher:long_running,geocruncher:priority
+uv run watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- celery -A api worker -l INFO -Q geocruncher:long_running,geocruncher:priority

--- a/uv.lock
+++ b/uv.lock
@@ -568,11 +568,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1746,11 +1746,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
See: https://trello.com/c/8kcSlyME/2187-computation-progress-bar
Linked to this PR on VISKAR: https://github.com/ISSKA/VISKAR/pull/1631

In order to implement a more advanced progress bar in VISKAR's frontend, we added metadata to the polling of job state.
This builds upon the profiler's code, and stores data through Celery that can be fetched before the job is completed.

We store:
- The current step
- When the current step was started
- How long we have already spent on this step in previous invocations

Since the steps are not necessarily linear, and some can be repeated (to profile loops for instance), this is not enough information to know for sure exactly where we are at in the progress, but it's enough to provide a useful estimate to the end user.
It was necessary to profile the start of the steps, on top of the previous profiling strategy that profiled the end of the steps. The overhead is minimal but still adds a bit of code to maintain.

Also in this PR:
- Properly forget task results that are non successful