### PR TITLE
Optimize intersections data by rounding to 2 decimals

### DIFF
--- a/geocruncher/compute_intersections.py
+++ b/geocruncher/compute_intersections.py
@@ -13,6 +13,9 @@ from forgeo.gmlib.GeologicalModel3D import Box, GeologicalModel
 from .mesh_io.mesh_io import read_mesh_to_polydata
 from .profiler import profile_step, start_step
 
+# How many decimals to return for all intersections data. Could be an API parameter, but that's probably overkill
+INTERSECTIONS_PRECISION = 2
+
 
 def calculate_resolution(width: float, height: float, res: int) -> tuple[int, int]:
     """Calculates a proportional resolution where the larger dimension matches `res`.
@@ -256,7 +259,10 @@ def project_hydro_features_on_slice(
         """
         delta_x = q[0] - p0[0]
         delta_y = q[1] - p0[1]
-        return [math.sqrt(delta_x**2 + delta_y**2), q[2]]
+        return [
+            round(math.sqrt(delta_x**2 + delta_y**2), INTERSECTIONS_PRECISION),
+            round(q[2], INTERSECTIONS_PRECISION),
+        ]
 
     matrix_gwb = []
     drillholes_line = {}

--- a/geocruncher/fault_intersections.py
+++ b/geocruncher/fault_intersections.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 import numpy as np
 from forgeo.gmlib.GeologicalModel3D import GeologicalModel
 
+from .compute_intersections import INTERSECTIONS_PRECISION
 from .profiler import profile_step, start_step
 
 CLIP_VALUE = np.nan
@@ -69,7 +70,9 @@ class FaultIntersector:
 
         # Evaluate all faults upfront
         for name, field in model.faults.items():
-            fault_potentials[name] = field(self._grid_points).reshape(res)
+            fault_potentials[name] = np.around(
+                field(self._grid_points).reshape(res), INTERSECTIONS_PRECISION
+            )
 
         # Process each fault in dependency order
         for name in self._sort_faults():


### PR DESCRIPTION
See: https://trello.com/c/dbZ30AIC/2367-limit-decimals-for-intersections-data

The data structure for the intersections computation will need a big improvement in the future. For now, rounding was added to the returned data (POI locations, fault potential field).
This results in halved output sizes for computations that include faults, improving saving and transfer performance.

As explained in the comment, the precision could be an API parameter, but for now that's probably a bit overkill.