### PR TITLE
Support dx dy headers in DEM

### DIFF
--- a/geocruncher/topography_reader.py
+++ b/geocruncher/topography_reader.py
@@ -24,19 +24,35 @@ def _header_float(pattern: str, line: str) -> float:
 def ascii_grid_to_implicit_dtm(dem: str) -> ImplicitDTM:
     """Read ASCIIGrid DEM datapoints and return a GMLIB ImplicitDTM."""
 
-    lines = dem.splitlines()
-    # We do not actually care about the first 2 line (ncols, nrows), skip them
-    xllcorner = _header_float(r"-?\d+\.?\d*", lines[2])
-    yllcorner = _header_float(r"-?\d+\.?\d*", lines[3])
-    cellsize = _header_float(r"\d+\.?\d*", lines[4])
+    USEFUL_HEADERS = {"xllcorner", "yllcorner", "cellsize", "dx", "dy"}
 
-    offset = 5  # Skip the required header lines
-    if len(lines) > offset and lines[offset].strip().startswith("NODATA_value"):
-        logger.warning("Skipping NODATA_value line")
+    headers: dict[str, float] = {}
+    lines = dem.splitlines()
+
+    offset = 0
+    for line in lines:
+        keyword, _, value = line.strip().partition(" ")
+        # Stop parsing headers when we reach the first line that starts with a number (first line of the data section)
+        if re.match(r"^[-\d]|^[+-]?(nan|inf)", keyword, re.IGNORECASE):
+            break
+        try:
+            parsed = float(value.strip())
+        except ValueError:
+            break
+        if keyword.lower() in USEFUL_HEADERS:
+            headers[keyword.lower()] = parsed
         offset += 1
+
+    xllcorner = headers["xllcorner"]
+    yllcorner = headers["yllcorner"]
+
+    if "cellsize" in headers:
+        dx = dy = headers["cellsize"]
+    elif "dx" in headers and "dy" in headers:
+        dx, dy = headers["dx"], headers["dy"]
 
     data_string = "\n".join(lines[offset:])
     zmap = np.loadtxt(StringIO(data_string), dtype=np.float64)
     zmap = zmap[::-1].T
 
-    return ImplicitDTM((xllcorner, yllcorner), (float(cellsize), float(cellsize)), zmap)
+    return ImplicitDTM((xllcorner, yllcorner), (dx, dy), zmap)

--- a/geocruncher/topography_reader.py
+++ b/geocruncher/topography_reader.py
@@ -14,13 +14,6 @@ from forgeo.gmlib.topography_reader import ImplicitDTM
 logger = logging.getLogger(__name__)
 
 
-def _header_float(pattern: str, line: str) -> float:
-    match = re.search(pattern, line)
-    if match is None:
-        raise ValueError(f"Invalid ASCIIGrid header line: {line}")
-    return float(match[0])
-
-
 def ascii_grid_to_implicit_dtm(dem: str) -> ImplicitDTM:
     """Read ASCIIGrid DEM datapoints and return a GMLIB ImplicitDTM."""
 
@@ -31,25 +24,36 @@ def ascii_grid_to_implicit_dtm(dem: str) -> ImplicitDTM:
 
     offset = 0
     for line in lines:
-        keyword, _, value = line.strip().partition(" ")
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2:
+            raise ValueError(f"Invalid header line: {line!r}")
+
+        keyword, value = parts
         # Stop parsing headers when we reach the first line that starts with a number (first line of the data section)
         if re.match(r"^[-\d]|^[+-]?(nan|inf)", keyword, re.IGNORECASE):
             break
         try:
             parsed = float(value.strip())
-        except ValueError:
-            break
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid value for header '{keyword}': {value!r} in DEM"
+            ) from e
         if keyword.lower() in USEFUL_HEADERS:
             headers[keyword.lower()] = parsed
         offset += 1
 
-    xllcorner = headers["xllcorner"]
-    yllcorner = headers["yllcorner"]
+    try:
+        xllcorner = headers["xllcorner"]
+        yllcorner = headers["yllcorner"]
+    except KeyError as e:
+        raise ValueError(f"Missing required header: {e.args[0]} in DEM") from e
 
     if "cellsize" in headers:
         dx = dy = headers["cellsize"]
     elif "dx" in headers and "dy" in headers:
         dx, dy = headers["dx"], headers["dy"]
+    else:
+        raise ValueError("Missing cellsize or dx/dy header in DEM.")
 
     data_string = "\n".join(lines[offset:])
     zmap = np.loadtxt(StringIO(data_string), dtype=np.float64)

--- a/tests/unit/geocruncher/test_topography_reader.py
+++ b/tests/unit/geocruncher/test_topography_reader.py
@@ -25,6 +25,28 @@ def test_ascii_grid_to_implicit_dtm_reads_valid_grid_with_nodata_header():
     np.testing.assert_allclose(dtm.z, np.array([[3, 1], [4, 2]], dtype=float))
 
 
+def test_ascii_grid_to_implicit_dtm_reads_valid_grid_with_dx_dy_header():
+    dem = "\n".join(
+        [
+            "ncols 2",
+            "nrows 2",
+            "xllcorner 10",
+            "yllcorner -20",
+            "dx 5",
+            "dy 5",
+            "NODATA_value -9999",
+            "1 2",
+            "3 4",
+        ]
+    )
+
+    dtm = ascii_grid_to_implicit_dtm(dem)
+
+    np.testing.assert_allclose(dtm.origin, np.array([10, -20], dtype=float))
+    np.testing.assert_allclose(dtm.steps, np.array([5, 5], dtype=float))
+    np.testing.assert_allclose(dtm.z, np.array([[3, 1], [4, 2]], dtype=float))
+
+
 def test_ascii_grid_to_implicit_dtm_reads_grid_without_optional_nodata_header():
     dem = "\n".join(
         [
@@ -57,5 +79,40 @@ def test_ascii_grid_to_implicit_dtm_rejects_malformed_header_values():
         ]
     )
 
-    with pytest.raises(ValueError, match="Invalid ASCIIGrid header line"):
+    with pytest.raises(
+        ValueError, match="Invalid value for header 'xllcorner': 'nope' in DEM"
+    ):
+        ascii_grid_to_implicit_dtm(dem)
+
+
+def test_ascii_grid_to_implicit_dtm_rejects_grid_with_missing_required_headers():
+    dem = "\n".join(
+        [
+            "ncols 2",
+            "nrows 2",
+            "xllcorner 10",
+            "NODATA_value -9999",
+            "1 2",
+            "3 4",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Missing required header: yllcorner in DEM"):
+        ascii_grid_to_implicit_dtm(dem)
+
+
+def test_ascii_grid_to_implicit_dtm_rejects_grid_without_resolution():
+    dem = "\n".join(
+        [
+            "ncols 2",
+            "nrows 2",
+            "xllcorner 10",
+            "yllcorner -20",
+            "NODATA_value -9999",
+            "1 2",
+            "3 4",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Missing cellsize or dx/dy header in DEM."):
         ascii_grid_to_implicit_dtm(dem)


### PR DESCRIPTION
Some DEMs upload have non-square cells. Instead of a single cellsize header in their ASCII representation, they have dx dy, which causes an error on parsing.

- Make DEM headers parsing more flexible to allow for either dx and dy or cellsize

SEE https://trello.com/c/xms7FlAH/1738-investigate-supporting-dem-dx-dy